### PR TITLE
AI Handling + Bug Fixes.

### DIFF
--- a/Tactical/Abilities/AbstractAbility.cs
+++ b/Tactical/Abilities/AbstractAbility.cs
@@ -78,8 +78,13 @@ public abstract class AbstractAbility : IEventSubscriber, IEventHandler<CombatEv
         set {_BASE_DICE = value;}}
     public List<AbilityTag> TAGS = new List<AbilityTag>();
 
+    // An ability is always considered "available" if its current cooldown is at zero.
     public bool IsAvailable {
         get { return curCooldown == 0; }
+    }
+    // Some abilities have additional conditions in order to be activated. IsActivatable can be overridden for those conditions, but in general just is a wrapper for IsAvailable.
+    public virtual bool IsActivatable {
+        get { return IsAvailable; }
     }
     
     public AbstractAbility(string ID, Localization.AbilityStrings ABILITY_STRINGS, AbilityType TYPE, int BASE_CD, int MIN_RANGE, int MAX_RANGE, bool useLaneTargeting, bool requiresUnit, HashSet<TargetingModifiers> targetingModifiers = null){

--- a/Tactical/Abilities/Attacks/Discharge.cs
+++ b/Tactical/Abilities/Attacks/Discharge.cs
@@ -10,7 +10,7 @@ public class Discharge : AbstractAbility {
     private static bool targetsLane = false;
     private static bool needsUnit = true;
 
-    private Die atkDie = new Die(DieType.PIERCE, 1, 6);
+    private Die atkDie = new Die(DieType.PIERCE, 5, 5);
 
     public Discharge(): base(
         id,

--- a/Tactical/Characters/AIBehavior.cs
+++ b/Tactical/Characters/AIBehavior.cs
@@ -1,0 +1,72 @@
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Godot;
+
+public abstract class AiBehavior {
+    public readonly AbstractCharacter OWNER;
+
+    public AiBehavior(AbstractCharacter OWNER){
+        this.OWNER = OWNER;
+    }
+    /// <summary>
+    /// Decide on an ability to use. The decision process should vary between implementations.
+    /// </summary>
+    public abstract void DecideAbilityToUse();
+}
+
+/// <summary>
+/// Units with this behavior will pick a random ability on their turn, and also pick a random target for that ability.
+/// </summary>
+public class AiBehaviorPureRandom : AiBehavior {
+
+    public AiBehaviorPureRandom(AbstractCharacter OWNER) : base(OWNER){}
+
+    public override void DecideAbilityToUse(){
+        List<AbstractAbility> usableAbilities = new();
+
+        Dictionary<AbstractAbility, List<(int lane, HashSet<AbstractCharacter> targets)>> cache = new();
+        // Go through all non-REACTION available abilities and determine whether we can use each one at the user's current position.
+        foreach (AbstractAbility ability in this.OWNER.AvailableAbilities.Where(ability => ability.TYPE != AbilityType.REACTION && ability.TYPE != AbilityType.SPECIAL)){
+            List<(int lane, HashSet<AbstractCharacter> targets)> targets = ability.GetValidTargets();
+            if (targets.Count == 0) {continue;}
+
+            usableAbilities.Add(ability);
+            cache[ability] = targets;           // Store the results for further use in this function w/o having to make another call.
+        }
+
+        if (usableAbilities.Count == 0) {
+            CombatManager.InputAbility(OWNER.abilities.Where(ability => ability.ID == "PASS").FirstOrDefault(), new List<AbstractCharacter>{this.OWNER});
+            return;
+        }
+        AbstractAbility abilityToUse = usableAbilities[Rng.RandiRange(0, usableAbilities.Count - 1)];
+        Logging.Log($"{this.OWNER.CHAR_NAME} activates {abilityToUse.NAME}.", Logging.LogLevel.ESSENTIAL);
+
+        List<(int lane, HashSet<AbstractCharacter> targets)> targeting = cache[abilityToUse];
+        if (!abilityToUse.useLaneTargeting) {
+            HashSet<AbstractCharacter> charTargets = new();
+            foreach ((int _, HashSet<AbstractCharacter> targetSet) in targeting){
+                charTargets.UnionWith(targetSet);
+            }
+            AbstractCharacter chosenChar = charTargets.ToList()[Rng.RandiRange(0, charTargets.Count - 1)];
+            CombatManager.InputAbility(abilityToUse, new List<AbstractCharacter>{chosenChar});
+        } else {
+            List<int> laneTargets = targeting.Select(_ => _.lane).ToList();
+            int laneChosen = laneTargets[Rng.RandiRange(0, laneTargets.Count - 1)];
+            CombatManager.InputAbility(abilityToUse, new List<int>{laneChosen});
+        }
+    }
+}
+
+/// <summary>
+/// Generally used for backline units. Will prioritize attacking far-away enemies. If enemies are nearby, priority is split between attacking far-away enemies and getting away from nearby enemies.
+/// </summary>
+public class AiBehaviorBackline : AiBehavior {
+
+    public AiBehaviorBackline(AbstractCharacter OWNER) : base(OWNER){}
+
+    public override void DecideAbilityToUse(){
+        return;
+    }
+}

--- a/Tactical/Characters/AIBehavior.cs
+++ b/Tactical/Characters/AIBehavior.cs
@@ -14,6 +14,11 @@ public abstract class AiBehavior {
     /// Decide on an ability to use. The decision process should vary between implementations.
     /// </summary>
     public abstract void DecideAbilityToUse();
+
+    /// <summary>
+    /// Decide on what abilities will be used as reactions this round.
+    /// </summary>
+    public abstract void DecideReactions();
 }
 
 /// <summary>
@@ -57,6 +62,10 @@ public class AiBehaviorPureRandom : AiBehavior {
             CombatManager.InputAbility(abilityToUse, new List<int>{laneChosen});
         }
     }
+
+    public override void DecideReactions() {
+        throw new NotImplementedException();
+    }
 }
 
 /// <summary>
@@ -68,5 +77,9 @@ public class AiBehaviorBackline : AiBehavior {
 
     public override void DecideAbilityToUse(){
         return;
+    }
+
+    public override void DecideReactions(){
+        throw new NotImplementedException();
     }
 }

--- a/Tactical/Characters/AbstractCharacter.cs
+++ b/Tactical/Characters/AbstractCharacter.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 public enum CharacterFaction {PLAYER, NEUTRAL, ENEMY};
 
@@ -9,6 +10,9 @@ public partial class AbstractCharacter : IEventSubscriber, IEventHandler<CombatE
     public string CHAR_NAME;
 
     public List<AbstractAbility> abilities = new();       // At the start of combat, deep-copy everything from PERMA_ABILITIES.
+    public List<AbstractAbility> AvailableAbilities {
+        get {return abilities.Where(ability => ability.IsAvailable).ToList();}
+    }
     public List<AbstractStatusEffect> statusEffects = new();
 
     private int _CurHP, _MaxHP, _CurPoise, _MaxPoise;
@@ -34,13 +38,10 @@ public partial class AbstractCharacter : IEventSubscriber, IEventHandler<CombatE
     public int Position;
 
     /// <summary>
-    /// Filled out by AI-controlled units only. The unit will use this ability on its turn. If ever made unavailable, a new intended action should be selected.
-    /// </summary>
-    public AbstractAbility actionIntent;
-    /// <summary>
     /// Filled out by AI-controlled units only. If targeted by a clashable attack, the unit will attempt to react with this ability. If the ability in question is ineligible to react, the target will choose not to react.
     /// </summary>
     public AbstractAbility reactionIntent;
+    public AiBehavior Behavior;
 
     public AbstractCharacter() : this(10, 10, 1, 5, CharacterFaction.NEUTRAL, "Unnamed Fighter") {}
     public AbstractCharacter(string name) : this(10, 10, 1, 5, CharacterFaction.NEUTRAL, name) {}
@@ -56,6 +57,7 @@ public partial class AbstractCharacter : IEventSubscriber, IEventHandler<CombatE
         this.ActionsPerTurn = 2;
         this.CHAR_FACTION = faction;
         this.CHAR_NAME = name;
+        this.Behavior = new AiBehaviorPureRandom(this);
 
         EquipAbility(new AbilityPass());
         EquipAbility(new AbilityMove());

--- a/Tactical/Characters/AbstractCharacter.cs
+++ b/Tactical/Characters/AbstractCharacter.cs
@@ -13,6 +13,9 @@ public partial class AbstractCharacter : IEventSubscriber, IEventHandler<CombatE
     public List<AbstractAbility> AvailableAbilities {
         get {return abilities.Where(ability => ability.IsAvailable).ToList();}
     }
+    public List<AbstractAbility> ActivatableAbilities {
+        get {return abilities.Where(ability => ability.IsActivatable).ToList();}
+    }
     public List<AbstractStatusEffect> statusEffects = new();
 
     private int _CurHP, _MaxHP, _CurPoise, _MaxPoise;

--- a/Tactical/Combat Actions/DamageAction.cs
+++ b/Tactical/Combat Actions/DamageAction.cs
@@ -35,6 +35,8 @@ public class DamageAction : AbstractAction {
             this.defender.CurHP -= (int) damageData.damageTaken;
         }
 
+        GD.Print($"{attacker.CHAR_NAME} attacks {defender.CHAR_NAME} dealing {damageData.damageTaken} {(isPoiseDamage ? "Poise " : "")}damage.");
+
         if (this.defender.CurPoise <= 0){
             // Note that passives which prevent stagger for the first time in combat should listen to CombatEventDamageDealt.
             CombatManager.ExecuteAction(new ApplyStatusAction(damageData.target, new ConditionStaggered(), stacksToApply: 2));

--- a/Tactical/Combat Actions/DamageAction.cs
+++ b/Tactical/Combat Actions/DamageAction.cs
@@ -35,7 +35,7 @@ public class DamageAction : AbstractAction {
             this.defender.CurHP -= (int) damageData.damageTaken;
         }
 
-        GD.Print($"{attacker.CHAR_NAME} attacks {defender.CHAR_NAME} dealing {damageData.damageTaken} {(isPoiseDamage ? "Poise " : "")}damage.");
+        Logging.Log($"{defender.CHAR_NAME} takes {damageData.damageTaken} {(isPoiseDamage ? "Poise " : "")}damage.", Logging.LogLevel.ESSENTIAL);
 
         if (this.defender.CurPoise <= 0){
             // Note that passives which prevent stagger for the first time in combat should listen to CombatEventDamageDealt.

--- a/Tactical/CombatEventManager.cs
+++ b/Tactical/CombatEventManager.cs
@@ -414,3 +414,24 @@ public class CombatEventUnitMoved : ICombatEvent {
         this.isForcedMovement = isForcedMovement;
     }
 }
+
+/// <summary>
+/// Only UI elements should listen to this event. Triggers when an enemy attacks a player character who has eligible reaction abilities.
+/// </summary>
+public class CombatEventClashEligible : ICombatEvent {
+    public CombatEventType eventType {
+        get {return CombatEventType.ON_CLASH_ELIGIBLE;}
+    }
+
+    public AbstractCharacter attacker;
+    public AbstractAbility attackerAbility;
+    public AbstractCharacter defender;
+    public List<AbstractAbility> reactableAbilities;
+
+    public CombatEventClashEligible(AbstractCharacter attacker, AbstractAbility attackerAbility, AbstractCharacter defender, List<AbstractAbility> reactableAbilities){
+        this.attacker = attacker;
+        this.attackerAbility = attackerAbility;
+        this.defender = defender;
+        this.reactableAbilities = reactableAbilities;
+    }
+}

--- a/Tactical/CombatEventManager.cs
+++ b/Tactical/CombatEventManager.cs
@@ -85,9 +85,11 @@ public partial class CombatEventManager{
         int i = 0;
         List<(IEventSubscriber subscriber, int priority)> eventSubscribers = events[eventData.eventType].GetQueue();
         while (i < eventSubscribers.Count){
+            Logging.Log($"Handling subscriber #{eventSubscribers.Count}. This one is {eventSubscribers[i].subscriber}.", Logging.LogLevel.DEBUG);
             (eventSubscribers[i].subscriber as IEventHandler<T>)?.HandleEvent(eventData);
             i += 1;
         }
+        events[eventData.eventType].RemoveAllInstancesOfItem(null);
         return eventData;
     }
 
@@ -100,13 +102,13 @@ public partial class CombatEventManager{
     // Remove a subscriber from a specified event type from the event dictionary.
     public void Unsubscribe(CombatEventType eventType, IEventSubscriber subscriber){
         if (!events.ContainsKey(eventType)){ return; }
-        events[eventType].RemoveAllInstancesOfItem(subscriber);
+        events[eventType].RemoveAllInstancesOfItem(subscriber, insteadMarkAsNull: true);
     }
 
     // Remove the provided subscriber from all events. Used in instances such as when a character is defeated.
     public void UnsubscribeAll(IEventSubscriber subscriber){
         foreach (CombatEventType eventType in events.Keys){
-            events[eventType].RemoveAllInstancesOfItem(subscriber);
+            events[eventType].RemoveAllInstancesOfItem(subscriber, insteadMarkAsNull: true);
         }
     }
 }

--- a/Tactical/CombatManager.cs
+++ b/Tactical/CombatManager.cs
@@ -106,7 +106,11 @@ public static class CombatManager {
                         InputAbility(null, new List<AbstractCharacter>{combatInstance.activeChar});
                     }
                     // Ai then moves to next reaction intent.
-                    ai.Behavior.reactions.RemoveAt(0);
+                    try {
+                        ai.Behavior.reactions.RemoveAt(0);
+                    } catch (Exception) {
+                        Logging.Log("AI unit had no remaining reactions to remove.", Logging.LogLevel.ESSENTIAL);
+                    }
                 } else {
                     // Player chooses an ability (since activeChar was AI).
                     AbstractCharacter defender = combatInstance.activeAbilityTargets.First();

--- a/Tactical/CombatManager.cs
+++ b/Tactical/CombatManager.cs
@@ -149,6 +149,9 @@ public static class CombatManager {
             for (int i = 0; i < character.ActionsPerTurn; i++){
                 combatInstance.turnlist.AddToQueue(character, Rng.RandiRange(character.MinSpd, character.MaxSpd));
             }
+            if (character.CHAR_FACTION != CharacterFaction.PLAYER){
+                // TODO: Decide reactions.
+            }
         }
         Logging.Log($"Starting round {combatInstance.round} with {combatInstance.turnlist.Count} actions in the queue.", Logging.LogLevel.INFO);
         eventManager.BroadcastEvent(new CombatEventRoundStart(combatInstance.round));
@@ -171,7 +174,10 @@ public static class CombatManager {
 
     private static void TurnEnd(){
         eventManager.BroadcastEvent(new CombatEventTurnEnd(combatInstance.activeChar, combatInstance.activeCharSpd));
-        combatInstance.turnlist.PopNextItem();
+        // If the active character is staggered, their actions are automatically removed from the turn queue, so only pop if the active character is not staggered.
+        if (combatInstance.turnlist.GetNextItem().element == combatInstance.activeChar){
+            combatInstance.turnlist.PopNextItem();
+        }
         if (combatInstance.turnlist.GetNextItem() == (null, 0)){
             Logging.Log("No remaining actions on the turnlist. Ending round.", Logging.LogLevel.INFO);
             ChangeCombatState(CombatState.ROUND_END);

--- a/Tactical/ModdablePriorityQueue.cs
+++ b/Tactical/ModdablePriorityQueue.cs
@@ -106,9 +106,25 @@ public partial class ModdablePriorityQueue<T>{
         return;
     }
 
-    /// <summary>Removes all of a character's actions from the queue (use when a character is staggered, killed, stunned, etc.).</summary>
-    public void RemoveAllInstancesOfItem(T elementToRemove){
-        this.queue.RemoveAll(item => item.element.Equals(elementToRemove));
+    /// <summary>
+    /// Removes or sets to default all of an element's appearances from the queue. Used for character turnlist (when a character is staggered, killed, stunned, etc.) and the event system.
+    /// </summary>
+    /// <param name="insteadMarkAsNull">
+    /// If true, will instead mark set the element to its default (e.g. null). This is useful in cases where the moddable priority queue does NOT want the overall order
+    /// to change, but does need to disable behavior of a set of elements. This is used for event handling; in a case where the Haste buff removes itself from RoundStart after use,
+    /// we need to mark it null instead of removing it outright from the moddable priority queue, as removing it would cause the *last* subscriber in RoundStart (UI elements) from getting
+    /// to trigger.
+    /// </param>
+    public void RemoveAllInstancesOfItem(T elementToRemove, bool insteadMarkAsNull = false){
+        if (insteadMarkAsNull){
+            this.queue.ForEach(item => {
+                if (item.element.Equals(elementToRemove)){
+                    item.element = default;
+                }
+            });
+        } else {
+            this.queue.RemoveAll(item => item.element.Equals(elementToRemove));
+        }
     }
 
     public List<(T element, int priority)> GetQueue(){

--- a/Tactical/ScenarioInfo.cs
+++ b/Tactical/ScenarioInfo.cs
@@ -32,14 +32,15 @@ public class TestScenario : ScenarioInfo {
         characterA.EquipAbility(new TestAttack());
         characterA.EquipAbility(new Discharge());
         characterA.EquipAbility(new Thwack());
-        characterA.MinSpd = -1;
-        characterA.MaxSpd = -1;
+        characterA.MinSpd = 10;
+        characterA.MaxSpd = 10;
 
         characterB.ActionsPerTurn = 1;
         characterB.MaxHP = 100;
         characterB.CurHP = 100;
         characterB.MaxPoise = 10;
         characterB.EquipAbility(new Thwack());
+        characterB.EquipAbility(new Discharge());
         characterB.Behavior = new AiBehaviorPureRandom(characterB);
         characterC.ActionsPerTurn = 0;
         characterD.ActionsPerTurn = 0;

--- a/Tactical/ScenarioInfo.cs
+++ b/Tactical/ScenarioInfo.cs
@@ -32,10 +32,9 @@ public class TestScenario : ScenarioInfo {
         characterA.EquipAbility(new TestAttack());
         characterA.EquipAbility(new Discharge());
         characterA.EquipAbility(new Thwack());
-        characterA.MinSpd = 10;
-        characterA.MaxSpd = 10;
+        characterA.MinSpd = 1;
+        characterA.MaxSpd = 5;
 
-        characterB.ActionsPerTurn = 1;
         characterB.MaxHP = 100;
         characterB.CurHP = 100;
         characterB.MaxPoise = 10;

--- a/Tactical/ScenarioInfo.cs
+++ b/Tactical/ScenarioInfo.cs
@@ -31,6 +31,7 @@ public class TestScenario : ScenarioInfo {
         characterA.EquipAbility(new RelentlessStabbing());
         characterA.EquipAbility(new TestAttack());
         characterA.EquipAbility(new Discharge());
+        characterA.EquipAbility(new Thwack());
         characterA.MinSpd = 5;
 
         characterB.ActionsPerTurn = 1;
@@ -38,6 +39,7 @@ public class TestScenario : ScenarioInfo {
         characterB.CurHP = 100;
         characterB.MaxPoise = 10;
         characterB.EquipAbility(new Thwack());
+        characterB.Behavior = new AiBehaviorPureRandom(characterB);
         characterC.ActionsPerTurn = 0;
         characterD.ActionsPerTurn = 0;
     }

--- a/Tactical/ScenarioInfo.cs
+++ b/Tactical/ScenarioInfo.cs
@@ -32,7 +32,8 @@ public class TestScenario : ScenarioInfo {
         characterA.EquipAbility(new TestAttack());
         characterA.EquipAbility(new Discharge());
         characterA.EquipAbility(new Thwack());
-        characterA.MinSpd = 5;
+        characterA.MinSpd = -1;
+        characterA.MaxSpd = -1;
 
         characterB.ActionsPerTurn = 1;
         characterB.MaxHP = 100;

--- a/Tactical/UI/Abilities/AbilityButton.cs
+++ b/Tactical/UI/Abilities/AbilityButton.cs
@@ -28,8 +28,8 @@ public partial class AbilityButton : Button
 
     private void UpdateDisplay(){
 		this.Text = Ability.NAME;
-		this.Disabled = !Ability.IsAvailable || (Ability.TYPE == AbilityType.REACTION && CombatManager.combatInstance.combatState != CombatState.AWAITING_CLASH_INPUT);
-		cdImageNode.Visible = !Ability.IsAvailable;
-		cdLabel.Text = !Ability.IsAvailable ? Ability.curCooldown.ToString() : "";
+		this.Disabled = !Ability.IsActivatable || (Ability.TYPE == AbilityType.REACTION && CombatManager.combatInstance.combatState != CombatState.AWAITING_CLASH_INPUT);
+		cdImageNode.Visible = !Ability.IsActivatable;
+		cdLabel.Text = !Ability.IsActivatable ? Ability.curCooldown.ToString() : "";
 	}
 }

--- a/Tactical/UI/Abilities/AbilityButton.cs
+++ b/Tactical/UI/Abilities/AbilityButton.cs
@@ -7,6 +7,8 @@ public partial class AbilityButton : Button
 	[Signal]
 	public delegate void AbilitySelectedEventHandler(AbilityButton button);
 
+	public bool clashBehavior;
+
 	private AbstractAbility _ability;
 	public AbstractAbility Ability {
 		get {return _ability;}
@@ -25,6 +27,10 @@ public partial class AbilityButton : Button
         base._Pressed();
 		EmitSignal(nameof(AbilitySelected), this);		// LINK - Tactical\UI\ActiveCharInterfaceLayer.cs:51
     }
+
+	public void SetEnabled(bool isEnabled){
+		this.Disabled = !isEnabled;
+	}
 
     private void UpdateDisplay(){
 		this.Text = Ability.NAME;

--- a/Tactical/UI/Abilities/AbilityButton.cs
+++ b/Tactical/UI/Abilities/AbilityButton.cs
@@ -7,8 +7,6 @@ public partial class AbilityButton : Button
 	[Signal]
 	public delegate void AbilitySelectedEventHandler(AbilityButton button);
 
-	public bool clashBehavior;
-
 	private AbstractAbility _ability;
 	public AbstractAbility Ability {
 		get {return _ability;}
@@ -27,10 +25,6 @@ public partial class AbilityButton : Button
         base._Pressed();
 		EmitSignal(nameof(AbilitySelected), this);		// LINK - Tactical\UI\ActiveCharInterfaceLayer.cs:51
     }
-
-	public void SetEnabled(bool isEnabled){
-		this.Disabled = !isEnabled;
-	}
 
     private void UpdateDisplay(){
 		this.Text = Ability.NAME;

--- a/Tactical/UI/ActiveCharInterfaceLayer.cs
+++ b/Tactical/UI/ActiveCharInterfaceLayer.cs
@@ -1,4 +1,5 @@
 using Godot;
+using System;
 using System.Collections.Generic;
 using UI;
 
@@ -71,7 +72,9 @@ public partial class ActiveCharInterfaceLayer : Control, IEventSubscriber, IEven
 	}
 
 	private void DeleteAbilityDetailPanel(){
-		RemoveChild(abilityDetailPanelInstance);
+		if (IsInstanceValid(abilityDetailPanelInstance)){
+			abilityDetailPanelInstance.QueueFree();
+		}
 	}
 
 	private void UpdateCharacterName(){
@@ -87,6 +90,7 @@ public partial class ActiveCharInterfaceLayer : Control, IEventSubscriber, IEven
 
     public void HandleEvent(CombatEventTurnStart data){
 		this.ActiveChar = data.character;
+		DeleteAbilityDetailPanel();			// TODO: This deletes the ability panel if a clash occurs (since MouseExited doesn't apply). Find a better way to do this.
 	}
 
 	public void HandleEvent(CombatEventClashEligible data){

--- a/Tactical/UI/Characters/CharacterUI.cs
+++ b/Tactical/UI/Characters/CharacterUI.cs
@@ -4,7 +4,7 @@ using System.Reflection.Metadata;
 
 namespace UI;
 
-public partial class CharacterUI : Control, IEventSubscriber, IEventHandler<CombatEventTurnEnd>
+public partial class CharacterUI : Control, IEventSubscriber, IEventHandler<CombatEventTurnEnd>, IEventHandler<CombatEventRoundStart>
 {
 	[Signal]
 	public delegate void CharacterSelectedEventHandler(CharacterUI character);
@@ -69,9 +69,14 @@ public partial class CharacterUI : Control, IEventSubscriber, IEventHandler<Comb
 	public virtual void InitSubscriptions(){
 		// TODO: Change this to something like ON_TAKE_DAMAGE or ON_HP_CHANGED instead.
 		CombatManager.eventManager?.Subscribe(CombatEventType.ON_TURN_END, this, CombatEventPriority.UI);
+		CombatManager.eventManager?.Subscribe(CombatEventType.ON_ROUND_START, this, CombatEventPriority.UI);
     }
 
     public void HandleEvent(CombatEventTurnEnd eventData){
+        UpdateStatsText();
+    }
+
+	public void HandleEvent(CombatEventRoundStart eventData){
         UpdateStatsText();
     }
 }

--- a/Tactical/UI/CombatInterface.cs
+++ b/Tactical/UI/CombatInterface.cs
@@ -20,18 +20,10 @@ public partial class CombatInterface : Control, IEventSubscriber, IEventHandler<
 		turnList = GetNode<Label>("Turn List");
 		parent = (GUIOrchestrator) GetParent();
 
-		UpdateRoundText();
 		UpdateTurnlistText();
 		UpdateCharPositions();
 
 		InitSubscriptions();
-	}
-
-	private void UpdateRoundText(){
-		CombatInstance combatInstance = CombatManager.combatInstance;
-		if (CombatManager.combatInstance != null) {
-			roundCounter.Text = $"Round {combatInstance.round}";
-		}
 	}
 
 	private void UpdateTurnlistText(){
@@ -82,7 +74,7 @@ public partial class CombatInterface : Control, IEventSubscriber, IEventHandler<
 	}
 
     public void HandleEvent(CombatEventRoundStart data){
-		UpdateRoundText();
+		roundCounter.Text = $"Round {data.roundStartNum}";
 	}
 
 	public void HandleEvent(CombatEventTurnStart data){

--- a/Tactical/UI/GUIOrchestrator.cs
+++ b/Tactical/UI/GUIOrchestrator.cs
@@ -12,7 +12,7 @@ public partial class GUIOrchestrator : Control, IEventSubscriber, IEventHandler<
 	private CombatInterface combatInterfaceNode;
 
 	public GUIOrchestrator(){
-		// TODO: Remove, this is for debugging
+		// TODO: Remove, this is for debugging. Should be done on game end before loading into the scene.
 		CombatManager.combatInstance = new CombatInstance(new TestScenario());
 		combatData = CombatManager.combatInstance;
 	}

--- a/Tactical/UI/GUIOrchestrator.cs
+++ b/Tactical/UI/GUIOrchestrator.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Godot;
 using UI;
 
-public partial class GUIOrchestrator : Control, IEventSubscriber, IEventHandler<CombatEventTurnStart>
+public partial class GUIOrchestrator : Control, IEventSubscriber, IEventHandler<CombatEventTurnStart>, IEventHandler<CombatEventClashEligible>
 {	
 	public readonly CombatInstance combatData;
 
@@ -22,6 +22,8 @@ public partial class GUIOrchestrator : Control, IEventSubscriber, IEventHandler<
 		promptTextNode = GetNode<Label>("Prompt Text");
 		activeCharNode = GetNode<ActiveCharInterfaceLayer>("Active Character");
 		combatInterfaceNode = GetNode<CombatInterface>("Combat Interface");
+		InitSubscriptions();
+
 		CombatManager.ChangeCombatState(CombatState.COMBAT_START);
 	}
 
@@ -68,6 +70,11 @@ public partial class GUIOrchestrator : Control, IEventSubscriber, IEventHandler<
 		}
 	}
 
+	public void _on_child_clash_selection(AbstractAbility ability){
+		clickedAbility = ability;
+		CombatManager.InputAbility(clickedAbility, new List<AbstractCharacter>{CombatManager.combatInstance?.activeChar});
+	}
+
 	public void _on_child_character_selection(AbstractCharacter character){
 		if (clickedAbility == null || character == null) return;
 		// TODO - This doesn't work with AoE attacks, figure out how to get *that* to work. Maybe we still just do this and have CombatEventManager.AbilityActivated modify the list of fighters post-hoc?
@@ -84,9 +91,14 @@ public partial class GUIOrchestrator : Control, IEventSubscriber, IEventHandler<
 
     public void InitSubscriptions(){
         CombatManager.eventManager.Subscribe(CombatEventType.ON_TURN_START, this, CombatEventPriority.UI);
+		CombatManager.eventManager.Subscribe(CombatEventType.ON_CLASH_ELIGIBLE, this, CombatEventPriority.UI);
     }
 
     public void HandleEvent(CombatEventTurnStart eventData){
         promptTextNode.Text = "";
     }
+
+	public void HandleEvent(CombatEventClashEligible eventData){
+		promptTextNode.Text = $"{eventData.attacker.CHAR_NAME} attacks {eventData.defender.CHAR_NAME} with {eventData.attackerAbility.NAME}.\nYou may choose an ability to begin a clash.";
+	}
 }


### PR DESCRIPTION
This PR **adds** the following:
- Base AI support, with a "completely-random" behavior.
- Clash display handling.


This PR **fixes** the following:
- A nasty bug where event management did not work well with ModdablePriorityQueue's RemoveAllInstancesOfItem, which could cause event subscribers later down the queue to not trigger if earlier subscribers removed themselves from the queue preemptively (e.g. Haste removing itself on round start).
- Removed activeChar being obtained through an automatic getter function. activeChar is now assigned during round start. The former method was causing issues if the active character was staggered during their action (which would remove their actions from the turn queue, causing all subsequent actions to fall through to the NEXT unit in the turn list instead).